### PR TITLE
[buffermgrd] [portsyncd] [vxlanmgrd] [mirrororch] fix a set of memory issues

### DIFF
--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -2853,7 +2853,7 @@ task_process_status BufferMgrDynamic::handleSingleBufferPgEntry(const string &ke
         // For del command:
         // 1. Removing it from APPL_DB
         // 2. Update internal caches
-        string &runningProfileName = bufferPg.running_profile_name;
+        string runningProfileName = bufferPg.running_profile_name;
         string &configProfileName = bufferPg.configured_profile_name;
 
         if (!m_supportRemoving)

--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -392,8 +392,8 @@ bool VxlanMgr::doVxlanDeleteTask(const KeyOpFieldsValuesTuple & t)
         SWSS_LOG_WARN("Vxlan %s hasn't been created ", info.m_vxlan.c_str());
     }
 
-    m_vnetCache.erase(it);
     SWSS_LOG_INFO("Delete vxlan %s", info.m_vxlan.c_str());
+    m_vnetCache.erase(it);
     return true;
 }
 

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -772,8 +772,7 @@ bool MirrorOrch::setUnsetPortMirror(Port port,
     if (set)
     {
         port_attr.value.objlist.count = 1;
-        port_attr.value.objlist.list = reinterpret_cast<sai_object_id_t *>(calloc(port_attr.value.objlist.count, sizeof(sai_object_id_t)));
-        port_attr.value.objlist.list[0] = sessionId;
+        port_attr.value.objlist.list = &sessionId;
     }
     else
     {

--- a/portsyncd/linksync.cpp
+++ b/portsyncd/linksync.cpp
@@ -2,7 +2,7 @@
 #include <errno.h>
 #include <system_error>
 #include <sys/socket.h>
-#include <linux/if.h>
+#include <net/if.h>
 #include <netlink/route/link.h>
 #include "logger.h"
 #include "netmsg.h"
@@ -33,16 +33,6 @@ const string LAG_PREFIX = "PortChannel";
 
 extern set<string> g_portSet;
 extern bool g_init;
-
-struct if_nameindex
-{
-    unsigned int if_index;
-    char *if_name;
-};
-extern "C" {
-    extern struct if_nameindex *if_nameindex (void) __THROW;
-    extern void if_freenameindex (struct if_nameindex *) __THROW;
-}
 
 LinkSync::LinkSync(DBConnector *appl_db, DBConnector *state_db) :
     m_portTableProducer(appl_db, APP_PORT_TABLE_NAME),

--- a/portsyncd/linksync.cpp
+++ b/portsyncd/linksync.cpp
@@ -50,10 +50,10 @@ LinkSync::LinkSync(DBConnector *appl_db, DBConnector *state_db) :
     m_statePortTable(state_db, STATE_PORT_TABLE_NAME),
     m_stateMgmtPortTable(state_db, STATE_MGMT_PORT_TABLE_NAME)
 {
-    struct if_nameindex *if_ni, *idx_p;
-    if_ni = if_nameindex();
+    std::shared_ptr<struct if_nameindex> if_ni(if_nameindex(), if_freenameindex);
+    struct if_nameindex *idx_p;
 
-    for (idx_p = if_ni;
+    for (idx_p = if_ni.get();
             idx_p != NULL && idx_p->if_index != 0 && idx_p->if_name != NULL;
             idx_p++)
     {
@@ -124,7 +124,7 @@ LinkSync::LinkSync(DBConnector *appl_db, DBConnector *state_db) :
             }
         }
 
-        for (idx_p = if_ni;
+        for (idx_p = if_ni.get();
                 idx_p != NULL && idx_p->if_index != 0 && idx_p->if_name != NULL;
                 idx_p++)
         {
@@ -154,8 +154,6 @@ LinkSync::LinkSync(DBConnector *appl_db, DBConnector *state_db) :
             }
         }
     }
-
-    if_freenameindex(if_ni);
 }
 
 void LinkSync::onMsg(int nlmsg_type, struct nl_object *obj)

--- a/portsyncd/linksync.cpp
+++ b/portsyncd/linksync.cpp
@@ -39,7 +39,10 @@ struct if_nameindex
     unsigned int if_index;
     char *if_name;
 };
-extern "C" { extern struct if_nameindex *if_nameindex (void) __THROW; }
+extern "C" {
+    extern struct if_nameindex *if_nameindex (void) __THROW;
+    extern void if_freenameindex (struct if_nameindex *) __THROW;
+}
 
 LinkSync::LinkSync(DBConnector *appl_db, DBConnector *state_db) :
     m_portTableProducer(appl_db, APP_PORT_TABLE_NAME),
@@ -151,6 +154,8 @@ LinkSync::LinkSync(DBConnector *appl_db, DBConnector *state_db) :
             }
         }
     }
+
+    if_freenameindex(if_ni);
 }
 
 void LinkSync::onMsg(int nlmsg_type, struct nl_object *obj)


### PR DESCRIPTION
**What I did**
Fixed the following memory issues:
* [buffermgrd] the "runningProfileName" is used after the object it references is deleted
* [portsyncd] the 'if_ni' is not freed
* [vxlanmgrd] the 'info' is used after the object it references is deleted
* [mirrororch] removed unneeded calloc()

ASAN reports(shortened for convenience):<details><summary>buffermgrd</summary>
```bash
=================================================================
==915==ERROR: AddressSanitizer: heap-use-after-free on address 0x60d000013610 at pc 0x5583b3773cf1 bp 0x7fff5d5ade00 sp 0x7fff5d5addf8
READ of size 8 at 0x60d000013610 thread T0
    #0 0x5583b3773cf0 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::c_str() const /usr/include/c++/8/bits/basic_string.h:2291
    #1 0x5583b3773cf0 in swss::BufferMgrDynamic::handleSingleBufferPgEntry() cfgmgr/buffermgrdyn.cpp:2889
    #2 0x5583b374c811 in swss::BufferMgrDynamic::handleBufferObjectTables() cfgmgr/buffermgrdyn.cpp:3131
    #3 0x5583b374cd3c in swss::BufferMgrDynamic::handleBufferPgTable() cfgmgr/buffermgrdyn.cpp:3153
    #4 0x5583b374efcb in swss::BufferMgrDynamic::doTask(Consumer&) cfgmgr/buffermgrdyn.cpp:3187
    #5 0x5583b37c5ad6 in Consumer::execute() ../orchagent/orch.cpp:235
    #6 0x5583b3708af1 in main cfgmgr/buffermgrd.cpp:277
    #7 0x7fcd9e1aa09a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)
    #8 0x5583b37122a9  (/usr/bin/buffermgrd+0x372a9)

0x60d000013610 is located 64 bytes inside of 136-byte region [0x60d0000135d0,0x60d000013658)
freed by thread T0 here:
    #0 0x7fcd9ec19aa0 in operator delete(void*) (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xebaa0)
    #9 0x5583b37733fc in swss::BufferMgrDynamic::handleSingleBufferPgEntry() cfgmgr/buffermgrdyn.cpp:2888
    #10 0x5583b374c811 in swss::BufferMgrDynamic::handleBufferObjectTables() cfgmgr/buffermgrdyn.cpp:3131
    #11 0x5583b374cd3c in swss::BufferMgrDynamic::handleBufferPgTable() cfgmgr/buffermgrdyn.cpp:3153
    #12 0x5583b374efcb in swss::BufferMgrDynamic::doTask(Consumer&) cfgmgr/buffermgrdyn.cpp:3187
    #13 0x5583b37c5ad6 in Consumer::execute() ../orchagent/orch.cpp:235
    #14 0x5583b3708af1 in main cfgmgr/buffermgrd.cpp:277
    #15 0x7fcd9e1aa09a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)

previously allocated by thread T0 here:
    #0 0x7fcd9ec18d30 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xead30)
    #1 0x5583b379f9a3 in __gnu_cxx::new_allocator<>::allocate(unsigned long, void const*) /usr/include/c++/8/ext/new_allocator.h:111
    #7 0x5583b3772756 in swss::BufferMgrDynamic::handleSingleBufferPgEntry() cfgmgr/buffermgrdyn.cpp:2755
    #8 0x5583b374c811 in swss::BufferMgrDynamic::handleBufferObjectTables() cfgmgr/buffermgrdyn.cpp:3131
    #9 0x5583b374cd3c in swss::BufferMgrDynamic::handleBufferPgTable() cfgmgr/buffermgrdyn.cpp:3153
    #10 0x5583b374efcb in swss::BufferMgrDynamic::doTask(Consumer&) cfgmgr/buffermgrdyn.cpp:3187
    #11 0x5583b37c5ad6 in Consumer::execute() ../orchagent/orch.cpp:235
    #12 0x5583b3708af1 in main cfgmgr/buffermgrd.cpp:277
    #13 0x7fcd9e1aa09a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)

SUMMARY: AddressSanitizer: heap-use-after-free /usr/include/c++/8/bits/basic_string.h:2291 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::c_str() const
Shadow bytes around the buggy address:
  0x0c1a7fffa670: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa
  0x0c1a7fffa680: fa fa fa fa fa fa fd fd fd fd fd fd fd fd fd fd
  0x0c1a7fffa690: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x0c1a7fffa6a0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c1a7fffa6b0: fd fd fa fa fa fa fa fa fa fa fd fd fd fd fd fd
=>0x0c1a7fffa6c0: fd fd[fd]fd fd fd fd fd fd fd fd fa fa fa fa fa
  0x0c1a7fffa6d0: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c1a7fffa6e0: fd fd fd fd fd fa fa fa fa fa fa fa fa fa fd fd
  0x0c1a7fffa6f0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c1a7fffa700: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c1a7fffa710: fd fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==915==ABORTING

```
</details>

,<details><summary>vxlanmgrd</summary>
```bash 
=================================================================
==826==ERROR: AddressSanitizer: heap-use-after-free on address 0x612000002c80 at pc 0x55a47be378a9 bp 0x7ffd920c7380 sp 0x7ffd920c7378
READ of size 8 at 0x612000002c80 thread T0
    #0 0x55a47be378a8 in std::__cxx11::basic_string<>::c_str() const /usr/include/c++/8/bits/basic_string.h:2291
    #1 0x55a47be378a8 in swss::VxlanMgr::doVxlanDeleteTask() cfgmgr/vxlanmgr.cpp:396
    #2 0x55a47be3dbfd in swss::VxlanMgr::doVxlanCreateTask() cfgmgr/vxlanmgr.cpp:354
    #3 0x55a47be3ee45 in swss::VxlanMgr::doTask(Consumer&) cfgmgr/vxlanmgr.cpp:220
    #4 0x55a47bebbbb6 in Consumer::execute() ../orchagent/orch.cpp:235
    #5 0x55a47be14ef1 in main cfgmgr/vxlanmgrd.cpp:156
    #6 0x7fef556ce09a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)
    #7 0x55a47be1ae29  (/usr/bin/vxlanmgrd+0x2be29)

0x612000002c80 is located 192 bytes inside of 288-byte region [0x612000002bc0,0x612000002ce0)
freed by thread T0 here:
    #0 0x7fef5613daa0 in operator delete(void*) (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xebaa0)
    #1 0x55a47be37601 in __gnu_cxx::new_allocator<>() /usr/include/c++/8/ext/new_allocator.h:125
    #8 0x55a47be37601 in swss::VxlanMgr::doVxlanDeleteTask() cfgmgr/vxlanmgr.cpp:395
    #9 0x55a47be3dbfd in swss::VxlanMgr::doVxlanCreateTask() cfgmgr/vxlanmgr.cpp:354
    #10 0x55a47be3ee45 in swss::VxlanMgr::doTask(Consumer&) cfgmgr/vxlanmgr.cpp:220
    #11 0x55a47bebbbb6 in Consumer::execute() ../orchagent/orch.cpp:235
    #12 0x55a47be14ef1 in main cfgmgr/vxlanmgrd.cpp:156
    #13 0x7fef556ce09a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)

previously allocated by thread T0 here:
    #0 0x7fef5613cd30 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xead30)
    #1 0x55a47be548c7 in __gnu_cxx::new_allocator<>::allocate(unsigned long, void const*) /usr/include/c++/8/ext/new_allocator.h:111
    #7 0x55a47be3e09e in swss::VxlanMgr::doVxlanCreateTask() cfgmgr/vxlanmgr.cpp:363
    #8 0x55a47be3ee45 in swss::VxlanMgr::doTask(Consumer&) cfgmgr/vxlanmgr.cpp:220
    #9 0x55a47beae3b5 in Orch::doTask() ../orchagent/orch.cpp:541
    #10 0x55a47be14ee5 in main cfgmgr/vxlanmgrd.cpp:151
    #11 0x7fef556ce09a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)

SUMMARY: AddressSanitizer: heap-use-after-free /usr/include/c++/8/bits/basic_string.h:2291 in std::__cxx11::basic_string<>::c_str() const
Shadow bytes around the buggy address:
  0x0c247fff8540: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c247fff8550: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c247fff8560: 00 00 00 00 00 00 00 00 00 00 00 00 00 06 fa fa
  0x0c247fff8570: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c247fff8580: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c247fff8590:[fd]fd fd fd fd fd fd fd fd fd fd fd fa fa fa fa
  0x0c247fff85a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c247fff85b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c247fff85c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c247fff85d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c247fff85e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==826==ABORTING

```
</details>

,<details><summary>mirrororch</summary>
```bash 

=================================================================
==456==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 176 byte(s) in 22 object(s) allocated from:
    #0 0x7f047b8d1518 in calloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9518)
    #1 0x5556f77582b6 in MirrorOrch::setUnsetPortMirror(swss::Port, bool, bool, unsigned long) orchagent/mirrororch.cpp:775
    #2 0x5556f77590a7 in MirrorOrch::configurePortMirrorSession(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, MirrorEntry&, bool) orchagent/mirrororch.cpp:840
    #3 0x5556f775d0fa in MirrorOrch::activateSession(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, MirrorEntry&) orchagent/mirrororch.cpp:1025
    #4 0x5556f775e6c5 in MirrorOrch::createEntry() orchagent/mirrororch.cpp:483
    #5 0x5556f776bcb7 in MirrorOrch::doTask(Consumer&) orchagent/mirrororch.cpp:1509
    #6 0x5556f73a6e96 in Consumer::execute() orchagent/orch.cpp:235
    #7 0x5556f7376d23 in OrchDaemon::start() orchagent/orchdaemon.cpp:707
    #8 0x5556f7225c70 in main orchagent/main.cpp:756
    #9 0x7f047ad4409a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)

Direct leak of 160 byte(s) in 20 object(s) allocated from:
    #0 0x7f047b8d1518 in calloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9518)
    #1 0x5556f77582b6 in MirrorOrch::setUnsetPortMirror(swss::Port, bool, bool, unsigned long) orchagent/mirrororch.cpp:775
    #2 0x5556f7759164 in MirrorOrch::configurePortMirrorSession(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, MirrorEntry&, bool) orchagent/mirrororch.cpp:849
    #3 0x5556f775d0fa in MirrorOrch::activateSession(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, MirrorEntry&) orchagent/mirrororch.cpp:1025
    #4 0x5556f775e6c5 in MirrorOrch::createEntry() orchagent/mirrororch.cpp:483
    #5 0x5556f776bcb7 in MirrorOrch::doTask(Consumer&) orchagent/mirrororch.cpp:1509
    #6 0x5556f73a6e96 in Consumer::execute() orchagent/orch.cpp:235
    #7 0x5556f7376d23 in OrchDaemon::start() orchagent/orchdaemon.cpp:707
    #8 0x5556f7225c70 in main orchagent/main.cpp:756
    #9 0x7f047ad4409a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)

Direct leak of 24 byte(s) in 3 object(s) allocated from:
    #0 0x7f047b8d1518 in calloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9518)
    #1 0x5556f77582b6 in MirrorOrch::setUnsetPortMirror(swss::Port, bool, bool, unsigned long) orchagent/mirrororch.cpp:775
    #2 0x5556f7759164 in MirrorOrch::configurePortMirrorSession(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, MirrorEntry&, bool) orchagent/mirrororch.cpp:849
    #3 0x5556f775d0fa in MirrorOrch::activateSession(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, MirrorEntry&) orchagent/mirrororch.cpp:1025
    #4 0x5556f775e6c5 in MirrorOrch::createEntry() orchagent/mirrororch.cpp:483
    #5 0x5556f776bcb7 in MirrorOrch::doTask(Consumer&) orchagent/mirrororch.cpp:1509
    #6 0x5556f7398c65 in Orch::doTask() orchagent/orch.cpp:541
    #7 0x5556f7376e50 in OrchDaemon::start() orchagent/orchdaemon.cpp:714
    #8 0x5556f7225c70 in main orchagent/main.cpp:756
    #9 0x7f047ad4409a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)

Direct leak of 24 byte(s) in 3 object(s) allocated from:
    #0 0x7f047b8d1518 in calloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9518)
    #1 0x5556f77582b6 in MirrorOrch::setUnsetPortMirror(swss::Port, bool, bool, unsigned long) orchagent/mirrororch.cpp:775
    #2 0x5556f77590a7 in MirrorOrch::configurePortMirrorSession(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, MirrorEntry&, bool) orchagent/mirrororch.cpp:840
    #3 0x5556f775d0fa in MirrorOrch::activateSession(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, MirrorEntry&) orchagent/mirrororch.cpp:1025
    #4 0x5556f775e6c5 in MirrorOrch::createEntry() orchagent/mirrororch.cpp:483
    #5 0x5556f776bcb7 in MirrorOrch::doTask(Consumer&) orchagent/mirrororch.cpp:1509
    #6 0x5556f7398c65 in Orch::doTask() orchagent/orch.cpp:541
    #7 0x5556f7376e50 in OrchDaemon::start() orchagent/orchdaemon.cpp:714
    #8 0x5556f7225c70 in main orchagent/main.cpp:756
    #9 0x7f047ad4409a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)

SUMMARY: AddressSanitizer: 384 byte(s) leaked in 48 allocation(s).

```
</details>

**Why I did it**
To fix memory usage issues

**How I verified it**
Run the tests that was used to find the issues and checked the ASAN report

**Details if related**
