### PR TITLE
[tests] [asan] add graceful stop flag

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,11 @@ def pytest_addoption(parser):
                      default="traditional",
                      help="Buffer model")
 
+    parser.addoption("--graceful-stop",
+                     action="store_true",
+                     default=False,
+                     help="Stop swss before stopping a conatainer")
+
 
 def random_string(size=4, chars=string.ascii_uppercase + string.digits):
     return "".join(random.choice(chars) for x in range(size))
@@ -1730,6 +1735,8 @@ def manage_dvs(request) -> str:
     max_cpu = request.config.getoption("--max_cpu")
     buffer_model = request.config.getoption("--buffer_model")
     force_recreate = request.config.getoption("--force-recreate-dvs")
+    graceful_stop = request.config.getoption("--graceful-stop")
+
     dvs = None
     curr_dvs_env = [] # lgtm[py/unused-local-variable]
 
@@ -1778,6 +1785,8 @@ def manage_dvs(request) -> str:
 
     yield update_dvs
 
+    if graceful_stop:
+        dvs.stop_swss()
     dvs.get_logs()
     dvs.destroy()
 


### PR DESCRIPTION
Currently, when running the tests with ASAN-enabled image, leak reports
are not generated. The reason is that dvs.destroy() (via 'ctn.remove(force=True)')
uses SIGKILL to stop the container. To address this, a new flag is
added.

When the new flag is set, the swss processes are gracefully stopped (via
SIGTERM).

Signed-off-by: Yakiv Huryk <yhuryk@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added a new flag to DVS tests
**Why I did it**
So ASAN reports can be generated as a result of DVS tests run
**How I verified it**
Run the tests with --graceful-stop, observe that swss processes are stopped via SIGTERM
**Details if related**
