### PR TITLE
[dash] add ACL group bind check for rule create/update

### DIFF
--- a/orchagent/dash/dashaclgroupmgr.cpp
+++ b/orchagent/dash/dashaclgroupmgr.cpp
@@ -494,12 +494,6 @@ task_process_status DashAclGroupMgr::updateRule(const string& group_id, const st
 {
     SWSS_LOG_ENTER();
 
-    if (isBound(group_id))
-    {
-        SWSS_LOG_INFO("Failed to update dash ACL rule %s:%s, ACL group is bound to the ENI", group_id.c_str(), rule_id.c_str());
-        return task_failed;
-    }
-
     if (ruleExists(group_id, rule_id))
     {
         removeRule(group_id, rule_id);
@@ -603,15 +597,15 @@ task_process_status DashAclGroupMgr::bind(const string& group_id, const string& 
     if (group_it == m_groups_table.end())
     {
         SWSS_LOG_INFO("Failed to bind ACL group %s to ENI %s. ACL group does not exist", group_id.c_str(), eni_id.c_str());
-        return task_need_retry;
+        return task_failed;
     }
 
     auto& group = group_it->second;
 
     if (group.m_dash_acl_rule_table.empty())
     {
-        SWSS_LOG_INFO("ACL group %s has no rules attached. Waiting for ACL rules creation", group_id.c_str());
-        return task_need_retry;
+        SWSS_LOG_INFO("Failed to bind ACL group %s to ENI %s. ACL group has no rules attached.", group_id.c_str(), eni_id.c_str());
+        return task_failed;
     }
 
     auto eni = m_dash_orch->getEni(eni_id);

--- a/orchagent/dash/dashaclgroupmgr.h
+++ b/orchagent/dash/dashaclgroupmgr.h
@@ -93,6 +93,7 @@ public:
     task_process_status create(const std::string& group_id, DashAclGroup& group);
     task_process_status remove(const std::string& group_id);
     bool exists(const std::string& group_id) const;
+    bool isBound(const std::string& group_id);
 
     void onUpdate(const std::string& group_id, const std::string& tag_id,const DashTag& tag);
 
@@ -114,7 +115,6 @@ private:
 
     void bind(const DashAclGroup& group, const EniEntry& eni, DashAclDirection direction, DashAclStage stage);
     void unbind(const DashAclGroup& group, const EniEntry& eni, DashAclDirection direction, DashAclStage stage);
-    bool isBound(const std::string &group_id);
     bool isBound(const DashAclGroup& group);
     void attachTags(const std::string &group_id, const std::unordered_set<std::string>& tags);
     void detachTags(const std::string &group_id, const std::unordered_set<std::string>& tags);

--- a/orchagent/dash/dashaclorch.cpp
+++ b/orchagent/dash/dashaclorch.cpp
@@ -272,6 +272,12 @@ task_process_status DashAclOrch::taskUpdateDashAclRule(
         return task_failed;
     }
 
+    if (m_group_mgr.isBound(group_id))
+    {
+        SWSS_LOG_INFO("Failed to set dash ACL rule %s:%s, ACL group is bound to the ENI", group_id.c_str(), rule_id.c_str());
+        return task_failed;
+    }
+
     if (m_group_mgr.ruleExists(group_id, rule_id))
     {
         return m_group_mgr.updateRule(group_id, rule_id, rule);


### PR DESCRIPTION
**What I did**
* add a check that prevents adding/editing rules in the bound group.
This is to enforce the behavior described in the [requirements](https://github.com/sonic-net/DASH/blob/main/documentation/general/dash-sonic-hld.md#17-acl-requirements)

* return error instead of retry for binding an empty group
Currently, the binding of an empty group is delayed until some rules are added to the group. This behavior is problematic since the delay is not deterministic, so adding a set of rules to such a group can lead to some rules being added and some rejected.

* add/update the VS tests
The test_empty_acl_group_binding is updated to do a bind once the group is not empty
A new test (test_acl_rule_after_group_bind) is added to verify rule creation for a bound group.

**Why I did it**
To improve DASH ACL implementation

**How I verified it**
DASH ACL VS tests

**Details if related**
