### PR TITLE
[dash] add a retry for an ACL rule creation if a tag is not created yet

### DIFF
--- a/orchagent/dash/dashaclgroupmgr.cpp
+++ b/orchagent/dash/dashaclgroupmgr.cpp
@@ -479,6 +479,20 @@ task_process_status DashAclGroupMgr::createRule(const string& group_id, const st
     auto acl_rule_it = group.m_dash_acl_rule_table.find(rule_id);
     ABORT_IF_NOT(acl_rule_it == group.m_dash_acl_rule_table.end(), "Failed to create ACL rule %s. Rule already exist in ACL group %s", rule_id.c_str(), group_id.c_str());
 
+    for (const auto& tag_id : rule.m_src_tags) {
+        if (!m_dash_acl_orch->getDashAclTagMgr().exists(tag_id)) {
+            SWSS_LOG_INFO("ACL tag %s doesn't exist, waiting for tag creating before creating rule %s", tag_id.c_str(), rule_id.c_str());
+            return task_need_retry;
+        }
+    }
+
+    for (const auto& tag_id : rule.m_dst_tags) {
+        if (!m_dash_acl_orch->getDashAclTagMgr().exists(tag_id)) {
+            SWSS_LOG_INFO("ACL tag %s doesn't exist, waiting for tag creating before creating rule %s", tag_id.c_str(), rule_id.c_str());
+            return task_need_retry;
+        }
+    }
+
     createRule(group, rule);
 
     group.m_dash_acl_rule_table.emplace(rule_id, rule);


### PR DESCRIPTION

**What I did**
Added a retry for DASH ACL rule creations if it contain a tag that is not created yet.

**Why I did it**
To align the implementation with the DASH ACL Tag design.

**How I verified it**

**Details if related**
