### PR TITLE
SRv6: update for uSID endpoint behavior mapping

### DIFF
--- a/orchagent/srv6orch.cpp
+++ b/orchagent/srv6orch.cpp
@@ -36,11 +36,11 @@ const map<string, sai_my_sid_entry_endpoint_behavior_t> end_behavior_map =
     {"end.b6.encaps.red",  SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_ENCAPS_RED},
     {"end.b6.insert",      SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_INSERT},
     {"end.b6.insert.red",  SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_INSERT_RED},
-    {"udx6",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX6},
-    {"udx4",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX4},
-    {"udt6",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT6},
-    {"udt4",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT4},
-    {"udt46",              SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT46},
+    {"udx6",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDX6},
+    {"udx4",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDX4},
+    {"udt6",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDT6},
+    {"udt4",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDT4},
+    {"udt46",              SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDT46},
     {"un",                 SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UN},
     {"ua",                 SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UA}
 };
@@ -622,7 +622,10 @@ bool Srv6Orch::mySidVrfRequired(const sai_my_sid_entry_endpoint_behavior_t end_b
     if (end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_T ||
         end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT4 ||
         end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT6 ||
-        end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT46)
+        end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT46 ||
+        end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDT4 ||
+        end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDT6 ||
+        end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDT46)
     {
       return true;
     }
@@ -634,6 +637,8 @@ bool Srv6Orch::mySidNextHopRequired(const sai_my_sid_entry_endpoint_behavior_t e
     if (end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_X ||
         end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX4 ||
         end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX6 ||
+        end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDX4 ||
+        end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDX6 ||
         end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_ENCAPS ||
         end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_ENCAPS_RED ||
         end_behavior == SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_INSERT ||

--- a/tests/test_srv6.py
+++ b/tests/test_srv6.py
@@ -313,7 +313,7 @@ class TestSrv6Mysid(object):
             if fv[0] == "SAI_MY_SID_ENTRY_ATTR_NEXT_HOP_ID":
                 assert fv[1] == next_hop_ipv4_id
             if fv[0] == "SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR":
-                assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX4"
+                assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDX4"
             elif fv[0] == "SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR_FLAVOR":
                 assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD"
 
@@ -331,7 +331,7 @@ class TestSrv6Mysid(object):
             if fv[0] == "SAI_MY_SID_ENTRY_ATTR_NEXT_HOP_ID":
                 assert fv[1] == next_hop_ipv6_id
             if fv[0] == "SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR":
-                assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX6"
+                assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDX6"
             elif fv[0] == "SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR_FLAVOR":
                 assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD"
 
@@ -1181,7 +1181,7 @@ class TestSrv6MySidFpmsyncd(object):
         assert status == True
         for fv in fvs:
             if fv[0] == "SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR":
-                assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT4"
+                assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDT4"
             if fv[0] == "SAI_MY_SID_ENTRY_ATTR_VRF":
                 assert fv[1] == self.vrf_id
 
@@ -1228,7 +1228,7 @@ class TestSrv6MySidFpmsyncd(object):
         assert status == True
         for fv in fvs:
             if fv[0] == "SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR":
-                assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT6"
+                assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDT6"
             if fv[0] == "SAI_MY_SID_ENTRY_ATTR_VRF":
                 assert fv[1] == self.vrf_id
 
@@ -1278,7 +1278,7 @@ class TestSrv6MySidFpmsyncd(object):
         assert status == True
         for fv in fvs:
             if fv[0] == "SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR":
-                assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT46"
+                assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDT46"
             if fv[0] == "SAI_MY_SID_ENTRY_ATTR_VRF":
                 assert fv[1] == self.vrf_id
 


### PR DESCRIPTION
**What I did**
Updated the mapping for uSID-related endpoint behavior to use new SAI attributes.

**Why I did it**
To correctly support a set of u-behaviours

**How I verified it**
Run vstest (test_srv6.py)

**Details if related**
