### PR TITLE
SRv6: add dscp_mode configuration for MySID entry

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -220,11 +220,17 @@ bool OrchDaemon::init()
     gFgNhgOrch = new FgNhgOrch(m_configDb, m_applDb, m_stateDb, fgnhg_tables, gNeighOrch, gIntfsOrch, vrf_orch);
     gDirectory.set(gFgNhgOrch);
 
-    vector<string> srv6_tables = {
-        APP_SRV6_SID_LIST_TABLE_NAME,
-        APP_SRV6_MY_SID_TABLE_NAME
+    TableConnector srv6_sid_list_table(m_applDb, APP_SRV6_SID_LIST_TABLE_NAME);
+    TableConnector srv6_my_sid_table(m_applDb, APP_SRV6_MY_SID_TABLE_NAME);
+    TableConnector srv6_my_sid_cfg_table(m_configDb, CFG_SRV6_MY_SID_TABLE_NAME);
+
+    vector<TableConnector> srv6_tables = {
+        srv6_sid_list_table,
+        srv6_my_sid_table,
+        srv6_my_sid_cfg_table
     };
-    gSrv6Orch = new Srv6Orch(m_applDb, srv6_tables, gSwitchOrch, vrf_orch, gNeighOrch);
+
+    gSrv6Orch = new Srv6Orch(m_configDb, m_applDb, srv6_tables, gSwitchOrch, vrf_orch, gNeighOrch);
     gDirectory.set(gSrv6Orch);
 
     const int routeorch_pri = 5;

--- a/orchagent/srv6orch.h
+++ b/orchagent/srv6orch.h
@@ -44,25 +44,42 @@ struct MySidEntry
     sai_my_sid_entry_endpoint_behavior_t endBehavior;
     string            endVrfString; // Used for END.T, END.DT4, END.DT6 and END.DT46,
     string            endAdjString; // Used for END.X, END.DX4, END.DX6
+    sai_tunnel_dscp_mode_t dscp_mode; // Used for UDT46
+    sai_object_id_t   tunnel_term_entry; // Used for UDT46
+};
+
+struct MySidIpInIpTunnel
+{
+    sai_object_id_t overlay_rif_oid;
+    sai_object_id_t tunnel_oid;
+    uint64_t refcount;
+};
+
+struct MySidIpInIpTunnels
+{
+    MySidIpInIpTunnel dscp_uniform_tunnel;
+    MySidIpInIpTunnel dscp_pipe_tunnel;
 };
 
 typedef unordered_map<string, SidTableEntry> SidTable;
 typedef unordered_map<string, SidTunnelEntry> Srv6TunnelTable;
 typedef map<NextHopKey, sai_object_id_t> Srv6NextHopTable;
 typedef unordered_map<string, MySidEntry> Srv6MySidTable;
+typedef unordered_map<string, sai_tunnel_dscp_mode_t> Srv6MySidDscpCfg;
 
 #define SID_LIST_DELIMITER ','
 #define MY_SID_KEY_DELIMITER ':'
 class Srv6Orch : public Orch, public Observer
 {
     public:
-        Srv6Orch(DBConnector *applDb, vector<string> &tableNames, SwitchOrch *switchOrch, VRFOrch *vrfOrch, NeighOrch *neighOrch):
-          Orch(applDb, tableNames),
+        Srv6Orch(DBConnector *cfgDb, DBConnector *applDb, const vector<TableConnector>& tables, SwitchOrch *switchOrch, VRFOrch *vrfOrch, NeighOrch *neighOrch):
+          Orch(tables),
           m_vrfOrch(vrfOrch),
           m_switchOrch(switchOrch),
           m_neighOrch(neighOrch),
           m_sidTable(applDb, APP_SRV6_SID_LIST_TABLE_NAME),
-          m_mysidTable(applDb, APP_SRV6_MY_SID_TABLE_NAME)
+          m_mysidTable(applDb, APP_SRV6_MY_SID_TABLE_NAME),
+          m_mysidCfgTable(cfgDb, CFG_SRV6_MY_SID_TABLE_NAME)
         {
             m_neighOrch->attach(this);
         }
@@ -78,6 +95,7 @@ class Srv6Orch : public Orch, public Observer
         void doTask(Consumer &consumer);
         task_process_status doTaskSidTable(const KeyOpFieldsValuesTuple &tuple);
         void doTaskMySidTable(const KeyOpFieldsValuesTuple &tuple);
+        void doTaskCfgMySidTable(const KeyOpFieldsValuesTuple &tuple);
         bool createUpdateSidList(const string seg_name, const string ips, const string sidlist_type);
         task_process_status deleteSidList(const string seg_name);
         bool createSrv6Tunnel(const string srv6_source);
@@ -87,20 +105,31 @@ class Srv6Orch : public Orch, public Observer
         bool deleteMysidEntry(const string my_sid_string);
         bool sidEntryEndpointBehavior(const string action, sai_my_sid_entry_endpoint_behavior_t &end_behavior,
                                       sai_my_sid_entry_endpoint_behavior_flavor_t &end_flavor);
+        bool getMySidEntryDscpMode(const string& my_sid, sai_tunnel_dscp_mode_t& dscp_mode);
         bool mySidExists(const string mysid_string);
         bool mySidVrfRequired(const sai_my_sid_entry_endpoint_behavior_t end_behavior);
         bool mySidNextHopRequired(const sai_my_sid_entry_endpoint_behavior_t end_behavior);
+        bool mySidTunnelRequired(const sai_my_sid_entry_endpoint_behavior_t end_behavior);
         void srv6TunnelUpdateNexthops(const string srv6_source, const NextHopKey nhkey, bool insert);
         size_t srv6TunnelNexthopSize(const string srv6_source);
+        bool initIpInIpTunnel(MySidIpInIpTunnel& tunnel, sai_tunnel_dscp_mode_t dscp_mode);
+        bool deinitIpInIpTunnel(MySidIpInIpTunnel& tunnel);
+        bool createMySidIpInIpTunnel(sai_tunnel_dscp_mode_t dscp_mode, sai_object_id_t& tunnel_oid);
+        bool removeMySidIpInIpTunnel(sai_tunnel_dscp_mode_t dscp_mode);
+        bool createMySidIpInIpTunnelTermEntry(sai_object_id_t tunnel_oid, const sai_ip6_t& sid_ip, sai_object_id_t& term_entry_oid);
+        bool removeMySidIpInIpTunnelTermEntry(sai_object_id_t term_entry_oid);
 
         void updateNeighbor(const NeighborUpdate& update);
 
         ProducerStateTable m_sidTable;
         ProducerStateTable m_mysidTable;
+        Table m_mysidCfgTable;
         SidTable sid_table_;
         Srv6TunnelTable srv6_tunnel_table_;
         Srv6NextHopTable srv6_nexthop_table_;
         Srv6MySidTable srv6_my_sid_table_;
+        MySidIpInIpTunnels my_sid_ipinip_tunnels_;
+        Srv6MySidDscpCfg my_sid_dscp_cfg_cache_;
         VRFOrch *m_vrfOrch;
         SwitchOrch *m_switchOrch;
         NeighOrch *m_neighOrch;

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -418,11 +418,16 @@ namespace aclorch_test
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
 
             ASSERT_EQ(gSrv6Orch, nullptr);
-            vector<string> srv6_tables = {
-                APP_SRV6_SID_LIST_TABLE_NAME,
-                APP_SRV6_MY_SID_TABLE_NAME
+            TableConnector srv6_sid_list_table(m_app_db.get(), APP_SRV6_SID_LIST_TABLE_NAME);
+            TableConnector srv6_my_sid_table(m_app_db.get(), APP_SRV6_MY_SID_TABLE_NAME);
+            TableConnector srv6_my_sid_cfg_table(m_config_db.get(), CFG_SRV6_MY_SID_TABLE_NAME);
+
+            vector<TableConnector> srv6_tables = {
+                srv6_sid_list_table,
+                srv6_my_sid_table,
+                srv6_my_sid_cfg_table
             };
-            gSrv6Orch = new Srv6Orch(m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
+            gSrv6Orch = new Srv6Orch(m_config_db.get(), m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
 
             ASSERT_EQ(gRouteOrch, nullptr);
             const int routeorch_pri = 5;

--- a/tests/mock_tests/flowcounterrouteorch_ut.cpp
+++ b/tests/mock_tests/flowcounterrouteorch_ut.cpp
@@ -201,11 +201,16 @@ namespace flowcounterrouteorch_test
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
 
             ASSERT_EQ(gSrv6Orch, nullptr);
-            vector<string> srv6_tables = {
-                APP_SRV6_SID_LIST_TABLE_NAME,
-                APP_SRV6_MY_SID_TABLE_NAME
+            TableConnector srv6_sid_list_table(m_app_db.get(), APP_SRV6_SID_LIST_TABLE_NAME);
+            TableConnector srv6_my_sid_table(m_app_db.get(), APP_SRV6_MY_SID_TABLE_NAME);
+            TableConnector srv6_my_sid_cfg_table(m_config_db.get(), CFG_SRV6_MY_SID_TABLE_NAME);
+
+            vector<TableConnector> srv6_tables = {
+                srv6_sid_list_table,
+                srv6_my_sid_table,
+                srv6_my_sid_cfg_table
             };
-            gSrv6Orch = new Srv6Orch(m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
+            gSrv6Orch = new Srv6Orch(m_config_db.get(), m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
 
             // Start FlowCounterRouteOrch
             static const  vector<string> route_pattern_tables = {

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -190,11 +190,16 @@ namespace intfsorch_test
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
 
             ASSERT_EQ(gSrv6Orch, nullptr);
-            vector<string> srv6_tables = {
-                APP_SRV6_SID_LIST_TABLE_NAME,
-                APP_SRV6_MY_SID_TABLE_NAME
+            TableConnector srv6_sid_list_table(m_app_db.get(), APP_SRV6_SID_LIST_TABLE_NAME);
+            TableConnector srv6_my_sid_table(m_app_db.get(), APP_SRV6_MY_SID_TABLE_NAME);
+            TableConnector srv6_my_sid_cfg_table(m_config_db.get(), CFG_SRV6_MY_SID_TABLE_NAME);
+
+            vector<TableConnector> srv6_tables = {
+                srv6_sid_list_table,
+                srv6_my_sid_table,
+                srv6_my_sid_cfg_table
             };
-            gSrv6Orch = new Srv6Orch(m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
+            gSrv6Orch = new Srv6Orch(m_config_db.get(), m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
 
             // Start FlowCounterRouteOrch
             static const  vector<string> route_pattern_tables = {

--- a/tests/mock_tests/mock_orch_test.cpp
+++ b/tests/mock_tests/mock_orch_test.cpp
@@ -185,11 +185,16 @@ void MockOrchTest::SetUp()
     gDirectory.set(gNhgOrch);
     ut_orch_list.push_back((Orch **)&gNhgOrch);
 
-    vector<string> srv6_tables = {
-        APP_SRV6_SID_LIST_TABLE_NAME,
-        APP_SRV6_MY_SID_TABLE_NAME
+    TableConnector srv6_sid_list_table(m_app_db.get(), APP_SRV6_SID_LIST_TABLE_NAME);
+    TableConnector srv6_my_sid_table(m_app_db.get(), APP_SRV6_MY_SID_TABLE_NAME);
+    TableConnector srv6_my_sid_cfg_table(m_config_db.get(), CFG_SRV6_MY_SID_TABLE_NAME);
+
+    vector<TableConnector> srv6_tables = {
+        srv6_sid_list_table,
+        srv6_my_sid_table,
+        srv6_my_sid_cfg_table
     };
-    gSrv6Orch = new Srv6Orch(m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
+    gSrv6Orch = new Srv6Orch(m_config_db.get(), m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
     gDirectory.set(gSrv6Orch);
     ut_orch_list.push_back((Orch **)&gSrv6Orch);
     gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -247,11 +247,16 @@ namespace routeorch_test
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
 
             ASSERT_EQ(gSrv6Orch, nullptr);
-            vector<string> srv6_tables = {
-                APP_SRV6_SID_LIST_TABLE_NAME,
-                APP_SRV6_MY_SID_TABLE_NAME
+            TableConnector srv6_sid_list_table(m_app_db.get(), APP_SRV6_SID_LIST_TABLE_NAME);
+            TableConnector srv6_my_sid_table(m_app_db.get(), APP_SRV6_MY_SID_TABLE_NAME);
+            TableConnector srv6_my_sid_cfg_table(m_config_db.get(), CFG_SRV6_MY_SID_TABLE_NAME);
+
+            vector<TableConnector> srv6_tables = {
+                srv6_sid_list_table,
+                srv6_my_sid_table,
+                srv6_my_sid_cfg_table
             };
-            gSrv6Orch = new Srv6Orch(m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
+            gSrv6Orch = new Srv6Orch(m_config_db.get(), m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
 
             ASSERT_EQ(gRouteOrch, nullptr);
             const int routeorch_pri = 5;


### PR DESCRIPTION
**What I did**
Added support for the "dscp_mode" MySID entry configuration:

* add a sync with CONFIG_DB to store MySID entry dscp mode
* create a tunnel/tunnel term entry for uDT46 MySID entry (the tunnel is reused for the same dscp_mode)
* add a new vs test

**Why I did it**
To support "dscp_mode" MySID entry configuration

**How I verified it**
New vstest `test_Srv6MySidUDT46TunnelDscpMode`

**Details if related**
