### PR TITLE
SRv6: the decap_dscp_mode configuration is now optional

### DIFF
--- a/orchagent/srv6orch.cpp
+++ b/orchagent/srv6orch.cpp
@@ -66,7 +66,7 @@ const map<string, sai_my_sid_entry_endpoint_behavior_flavor_t> end_flavor_map =
     {"end",                SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD},
     {"end.x",              SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD},
     {"end.t",              SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD},
-    {"un",                 SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD},
+    {"un",                 SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_NONE},
     {"ua",                 SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD}
 };
 
@@ -379,23 +379,22 @@ void Srv6Orch::addMySidCfgCacheEntry(const string& my_sid_key, const vector<Fiel
     auto key_list = tokenize(my_sid_key, '|');
     auto locator = key_list[0];
     auto my_sid_prefix = key_list[1];
+    boost::optional<sai_tunnel_dscp_mode_t> dscp_mode = boost::none;
 
     auto cfg = fvsGetValue(fvs, "decap_dscp_mode", false);
-    if (!cfg)
+    if (cfg)
     {
-        SWSS_LOG_ERROR("MySID entry %s doesn't have mandatory decap_dscp_mode configuration", my_sid_prefix.c_str());
-        return;
-    }
-
-    sai_tunnel_dscp_mode_t dscp_mode;
-    if (!mySidDscpModeToSai(*cfg, dscp_mode))
-    {
-        SWSS_LOG_ERROR("Invalid MySID %s DSCP mode: %s", my_sid_prefix.c_str(), cfg->c_str());
-        return;
+        sai_tunnel_dscp_mode_t dscp_mode_sai;
+        if (!mySidDscpModeToSai(*cfg, dscp_mode_sai))
+        {
+            SWSS_LOG_ERROR("Invalid MySID %s DSCP mode: %s", my_sid_prefix.c_str(), cfg->c_str());
+            return;
+        }
+        dscp_mode = dscp_mode_sai;
     }
 
     my_sid_dscp_cfg_cache_.insert({my_sid_prefix, {locator, dscp_mode}});
-    SWSS_LOG_INFO("Saving MySID entry %s %s DSCP mode %s", locator.c_str(), my_sid_prefix.c_str(), cfg->c_str());
+    SWSS_LOG_INFO("Saving MySID entry %s %s DSCP mode %s", locator.c_str(), my_sid_prefix.c_str(), cfg ? cfg->c_str() : "none");
 }
 
 void Srv6Orch::removeMySidCfgCacheEntry(const string& my_sid_key)
@@ -428,7 +427,7 @@ void Srv6Orch::mySidCfgCacheRefresh()
     }
 }
 
-bool Srv6Orch::getMySidEntryDscpMode(const string& my_sid_addr, const MySidLocatorCfg& locator_cfg, sai_tunnel_dscp_mode_t& dscp_mode)
+bool Srv6Orch::getMySidEntryDscpMode(const string& my_sid_addr, const MySidLocatorCfg& locator_cfg, boost::optional<sai_tunnel_dscp_mode_t>& dscp_mode)
 {
     auto my_sid_prefix = getMySidPrefix(my_sid_addr, locator_cfg);
 
@@ -1415,7 +1414,7 @@ bool Srv6Orch::mySidNextHopRequired(const sai_my_sid_entry_endpoint_behavior_t e
     return false;
 }
 
-bool Srv6Orch::mySidTunnelRequired(const string& my_sid_addr, const sai_my_sid_entry_t& sai_entry, sai_my_sid_entry_endpoint_behavior_t end_behavior, sai_tunnel_dscp_mode_t& dscp_mode)
+bool Srv6Orch::mySidTunnelRequired(const string& my_sid_addr, const sai_my_sid_entry_t& sai_entry, sai_my_sid_entry_endpoint_behavior_t end_behavior, boost::optional<sai_tunnel_dscp_mode_t>& dscp_mode)
 {
     if (end_behavior != SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UN &&
         end_behavior != SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDT46)
@@ -1425,7 +1424,8 @@ bool Srv6Orch::mySidTunnelRequired(const string& my_sid_addr, const sai_my_sid_e
 
     auto locator_cfg = getMySidEntryLocatorCfg(sai_entry);
 
-    return getMySidEntryDscpMode(my_sid_addr, locator_cfg, dscp_mode);
+    auto status = getMySidEntryDscpMode(my_sid_addr, locator_cfg, dscp_mode);
+    return status && dscp_mode.has_value();
 }
 
 bool Srv6Orch::createUpdateMysidEntry(string my_sid_string, const string dt_vrf, const string adj, const string end_action)
@@ -1547,11 +1547,11 @@ bool Srv6Orch::createUpdateMysidEntry(string my_sid_string, const string dt_vrf,
         nh_update = true;
     }
 
-    sai_tunnel_dscp_mode_t dscp_mode;
+    boost::optional<sai_tunnel_dscp_mode_t> dscp_mode;
     if (mySidTunnelRequired(my_sid_string, my_sid_entry, end_behavior, dscp_mode))
     {
         sai_object_id_t tunnel_oid;
-        auto ok = createMySidIpInIpTunnel(dscp_mode, tunnel_oid);
+        auto ok = createMySidIpInIpTunnel(dscp_mode.get(), tunnel_oid);
         if (!ok)
         {
             return false;
@@ -1561,12 +1561,12 @@ bool Srv6Orch::createUpdateMysidEntry(string my_sid_string, const string dt_vrf,
         ok = createMySidIpInIpTunnelTermEntry(tunnel_oid, my_sid_entry.sid, term_entry_oid);
         if (!ok)
         {
-            removeMySidIpInIpTunnel(dscp_mode);
+            removeMySidIpInIpTunnel(dscp_mode.get());
             return false;
         }
 
         srv6_my_sid_table_[key_string].tunnel_term_entry = term_entry_oid;
-        srv6_my_sid_table_[key_string].dscp_mode = dscp_mode;
+        srv6_my_sid_table_[key_string].dscp_mode = dscp_mode.get();
 
         attr.id = SAI_MY_SID_ENTRY_ATTR_TUNNEL_ID;
         attr.value.oid = tunnel_oid;

--- a/orchagent/srv6orch.h
+++ b/orchagent/srv6orch.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <set>
 #include <unordered_map>
+#include <boost/optional.hpp>
 
 #include "dbconnector.h"
 #include "orch.h"
@@ -144,7 +145,7 @@ typedef map<string, Srv6PrefixAggIdEntry> Srv6PrefixAggIdTableForNhg;
 typedef set<uint32_t> Srv6PrefixAggIdSet;
 typedef map<Srv6TunnelMapEntryKey, Srv6TunnelMapEntryEntry> Srv6TunnelMapEntryTable;
 typedef map<string, Srv6PicContextInfo> Srv6PicContextTable;
-typedef pair<string, sai_tunnel_dscp_mode_t> Srv6MySidDscpCfgCacheVal;
+typedef pair<string, boost::optional<sai_tunnel_dscp_mode_t>> Srv6MySidDscpCfgCacheVal;
 typedef std::unordered_multimap<string, Srv6MySidDscpCfgCacheVal> Srv6MySidDscpCfg;
 
 #define SID_LIST_DELIMITER ','
@@ -196,11 +197,11 @@ class Srv6Orch : public Orch, public Observer
         void mySidCfgCacheRefresh();
         void addMySidCfgCacheEntry(const string& my_sid_key, const vector<FieldValueTuple>& fvs);
         void removeMySidCfgCacheEntry(const string& my_sid_key);
-        bool getMySidEntryDscpMode(const string& my_sid_addr, const MySidLocatorCfg& locator_cfg, sai_tunnel_dscp_mode_t& dscp_mode);
+        bool getMySidEntryDscpMode(const string& my_sid_addr, const MySidLocatorCfg& locator_cfg, boost::optional<sai_tunnel_dscp_mode_t>& dscp_mode);
         bool mySidExists(const string mysid_string);
         bool mySidVrfRequired(const sai_my_sid_entry_endpoint_behavior_t end_behavior);
         bool mySidNextHopRequired(const sai_my_sid_entry_endpoint_behavior_t end_behavior);
-        bool mySidTunnelRequired(const string& my_sid_addr, const sai_my_sid_entry_t& sai_entry, sai_my_sid_entry_endpoint_behavior_t end_behavior, sai_tunnel_dscp_mode_t& dscp_mode);
+        bool mySidTunnelRequired(const string& my_sid_addr, const sai_my_sid_entry_t& sai_entry, sai_my_sid_entry_endpoint_behavior_t end_behavior, boost::optional<sai_tunnel_dscp_mode_t>& dscp_mode);
         void srv6TunnelUpdateNexthops(const string srv6_source, const NextHopKey nhkey, bool insert);
         size_t srv6TunnelNexthopSize(const string srv6_source);
         bool initIpInIpTunnel(MySidIpInIpTunnel& tunnel, sai_tunnel_dscp_mode_t dscp_mode);

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -75,6 +75,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 dashportmaporch_ut.cpp \
                 twamporch_ut.cpp \
                 stporch_ut.cpp \
+                srv6orch_ut.cpp \
                 flexcounter_ut.cpp \
                 portphyattr_ut.cpp \
                 counternameupdater_ut.cpp \

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -90,6 +90,7 @@ extern sai_router_interface_api_t *sai_router_intfs_api;
 extern sai_route_api_t *sai_route_api;
 extern sai_neighbor_api_t *sai_neighbor_api;
 extern sai_tunnel_api_t *sai_tunnel_api;
+extern sai_srv6_api_t *sai_srv6_api;
 extern sai_next_hop_api_t *sai_next_hop_api;
 extern sai_next_hop_group_api_t *sai_next_hop_group_api;
 extern sai_hostif_api_t *sai_hostif_api;

--- a/tests/mock_tests/srv6orch_ut.cpp
+++ b/tests/mock_tests/srv6orch_ut.cpp
@@ -1,0 +1,116 @@
+#include "mock_orch_test.h"
+#include "mock_orchagent_main.h"
+#include "mock_sai_api.h"
+#include "ut_helper.h"
+
+#include <gtest/gtest.h>
+#include <deque>
+
+using namespace std;
+using namespace swss;
+
+EXTERN_MOCK_FNS
+
+namespace srv6orch_test
+{
+
+DEFINE_SAI_GENERIC_API_MOCK(tunnel, tunnel);
+DEFINE_SAI_API_MOCK(srv6, my_sid);
+
+using ::testing::_;
+using ::testing::AtLeast;
+using namespace mock_orch_test;
+
+class Srv6OrchMySidTest : public MockOrchTest
+{
+protected:
+    void PostSetUp() override
+    {
+        INIT_SAI_API_MOCK(tunnel);
+        INIT_SAI_API_MOCK(srv6);
+        MockSaiApis();
+    }
+
+    void PreTearDown() override
+    {
+        RestoreSaiApis();
+        DEINIT_SAI_API_MOCK(srv6);
+        DEINIT_SAI_API_MOCK(tunnel);
+    }
+
+    void addLocatorConfig(const string& locator_name)
+    {
+        Table locator_table(m_config_db.get(), CFG_SRV6_MY_LOCATOR_TABLE_NAME);
+        vector<FieldValueTuple> fvs = {
+            {"block_len", "32"},
+            {"node_len", "16"},
+            {"func_len", "16"},
+            {"arg_len", "0"}
+        };
+        locator_table.set(locator_name, fvs);
+    }
+
+    void runCfgMySidTask(const string& key, const vector<FieldValueTuple>& fvs, bool is_set = true)
+    {
+        auto* executor = static_cast<Orch*>(gSrv6Orch)->getExecutor(CFG_SRV6_MY_SID_TABLE_NAME);
+        auto* consumer = dynamic_cast<Consumer*>(executor);
+        ASSERT_NE(consumer, nullptr);
+        deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({key, is_set ? SET_COMMAND : DEL_COMMAND, fvs});
+        consumer->addToSync(entries);
+        static_cast<Orch*>(gSrv6Orch)->doTask(*consumer);
+    }
+
+    void runAppMySidTask(const string& key, const string& action, const string& vrf,
+                        const string& adj, bool is_set = true)
+    {
+        auto* executor = static_cast<Orch*>(gSrv6Orch)->getExecutor(APP_SRV6_MY_SID_TABLE_NAME);
+        auto* consumer = dynamic_cast<Consumer*>(executor);
+        ASSERT_NE(consumer, nullptr);
+        vector<FieldValueTuple> fvs = {{"action", action}};
+        if (!vrf.empty())
+            fvs.push_back({"vrf", vrf});
+        if (!adj.empty())
+            fvs.push_back({"adj", adj});
+        deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({key, is_set ? SET_COMMAND : DEL_COMMAND, fvs});
+        consumer->addToSync(entries);
+        static_cast<Orch*>(gSrv6Orch)->doTask(*consumer);
+    }
+};
+
+TEST_F(Srv6OrchMySidTest, MySidEntryCreation_WithDecapDscpMode)
+{
+    ASSERT_NE(gSrv6Orch, nullptr);
+
+    const string locator = "loc1";
+    const string my_sid_prefix = "fc00:0:1:1::/64";
+    const string cfg_key = locator + "|" + my_sid_prefix;
+    const string app_key = "32:16:16:0:fc00:0:1:1::";
+
+    addLocatorConfig(locator);
+
+    EXPECT_CALL(*mock_sai_tunnel_api, create_tunnel(_, _, _, _)).Times(AtLeast(1));
+
+    runCfgMySidTask(cfg_key, {{"decap_dscp_mode", "uniform"}});
+    runAppMySidTask(app_key, "un", "default", "");
+}
+
+TEST_F(Srv6OrchMySidTest, MySidEntryCreation_WithoutDecapDscpMode)
+{
+    ASSERT_NE(gSrv6Orch, nullptr);
+
+    const string locator = "loc1";
+    const string my_sid_prefix = "fc00:0:1:1::/64";
+    const string cfg_key = locator + "|" + my_sid_prefix;
+    const string app_key = "32:16:16:0:fc00:0:1:1::";
+
+    addLocatorConfig(locator);
+
+    EXPECT_CALL(*mock_sai_tunnel_api, create_tunnel(_, _, _, _)).Times(0);
+
+    runCfgMySidTask(cfg_key, {});
+    runAppMySidTask(app_key, "un", "default", "");
+}
+
+} // namespace srv6orch_test

--- a/tests/mock_tests/ut_saihelper.cpp
+++ b/tests/mock_tests/ut_saihelper.cpp
@@ -75,6 +75,7 @@ namespace ut_helper
         sai_api_query(SAI_API_ROUTE, (void **)&sai_route_api);
         sai_api_query(SAI_API_NEIGHBOR, (void **)&sai_neighbor_api);
         sai_api_query(SAI_API_TUNNEL, (void **)&sai_tunnel_api);
+        sai_api_query(SAI_API_SRV6, (void **)&sai_srv6_api);
         sai_api_query(SAI_API_NEXT_HOP, (void **)&sai_next_hop_api);
         sai_api_query(SAI_API_NEXT_HOP_GROUP, (void **)&sai_next_hop_group_api);
         sai_api_query(SAI_API_ACL, (void **)&sai_acl_api);
@@ -127,6 +128,7 @@ namespace ut_helper
         sai_route_api = nullptr;
         sai_neighbor_api = nullptr;
         sai_tunnel_api = nullptr;
+        sai_srv6_api = nullptr;
         sai_next_hop_api = nullptr;
         sai_acl_api = nullptr;
         sai_hostif_api = nullptr;


### PR DESCRIPTION
**What I did**
The SRv6 MySID decap_dscp_mode configuration is now optional. When not configured, the tunnel-related configuration is not created.

**Why I did it**
To add an ability to have the SRv6 configuration without the tunnel.

**How I verified it**

**Details if related**
